### PR TITLE
Adding fileserver.dino.icu

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -4882,3 +4882,7 @@ gh-proxy:
   ttl: 300
   type: CNAME
   value: b.selfhosted.hackclub.com.
+fileserver:
+  - ttl: 600
+    type: CNAME
+    value: 6f453c7a-030b-4adb-9b7f-c1670a62af73.cfargotunnel.com.


### PR DESCRIPTION
# Adding `fileserver.dino.icu`

## Description

Added subdomain that (should) route through a Cloudflare tunnel to my Raspberry Pi to host a fileserver with a static link.

The fileserver.dino.icu subdomain will be used to host a self-managed file server for sharing resources, tools, and media. It uses a Cloudflare Tunnel to ensure secure, encrypted access without exposing the device directly to the internet.
